### PR TITLE
Clarify minimum version of CC licenses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ is clearly stated and verifiable. Suitable licenses include:
   * X/MIT
   * BSD 2/3/4 clause
   * CC0
-  * CC-BY
-  * CC-BY-SA
+  * CC-BY (v3.0 or later)
+  * CC-BY-SA (v3.0 or later)
 
 ## Horizontal grids
 


### PR DESCRIPTION
The older versions are not compatible with the DFSG and OSD.

> In contrast to the CC-SA 1.0 license, version 3.0 is considered to be
> compatible to the DFSG. In addition, the version 2.0 and 2.5 are NOT
> transitively compatible because of clause 4b, since that only allows
> redistribution of derivative works under later versions of the license.

https://wiki.debian.org/DFSGLicenses#Creative_Commons_Attribution_Share-Alike_.28CC-BY-SA.29_v3.0