### PR TITLE
Add NTV2_0.GSB for Canada

### DIFF
--- a/README.DATUMGRID
+++ b/README.DATUMGRID
@@ -36,9 +36,11 @@ is clearly stated and verifiable. Suitable licenses include:
 *Source*: [Natural Resources Canada](http://www.nrcan.gc.ca/earth-sciences/geomatics/geodetic-reference-systems/18766)  
 *Format* NTv1  
 *License*: Public Domain
-* ntv1_can.dat
 
-Grid conversion from NAD27 to NAD83 in Canada
+Grid conversion from NAD27 to NAD83 in Canada. This file is superseded by a
+higher resolution NTV2_0.GSB grid.
+
+* ntv1_can.dat
 
 ### France: NTF -> RGF93
 

--- a/north-america/README.NORTHAMERICA
+++ b/north-america/README.NORTHAMERICA
@@ -13,6 +13,16 @@ package.
 
 ## Included grids
 
+### Canada: NAD27 -> NAD83
+
+*Source*: [Natural Resources Canada](https://open.canada.ca/data/en/dataset/b3534942-31ea-59cf-bcc3-f8dc4875081a)  
+*Format*: NTv2  
+*License*: [Open Government Licence - Canada](http://open.canada.ca/en/open-government-licence-canada)
+
+Transform between NAD27 and NAD83 in Canada.
+
+* NTV2_0.GSB
+
 ### Greenland: GRS80 ellipsoidal heights -> GVR2016
 
 *Source*: [Agency for Data Supply and Efficiency](https://github.com/NordicGeodesy/NordicTransformations)  


### PR DESCRIPTION
Resolves #26

This PR does not rename the file, and it is kept uppercase. This may cause issues on POSIX systems, as there are examples that use the lowercase name (e.g. [ntv2_0.gsb](https://github.com/OSGeo/proj.4/wiki/GenParms#skipping-missing-grids)), or mixed case (e.g. [ntv2_0.GSB](https://github.com/DotSpatial/DotSpatial/blob/master/Source/DotSpatial.Projections.Tests/GeogTransformGrids/ntv2_0.GSB), [NTV2_0.gsb or Ntv2_0.gsb](https://knowledge.autodesk.com/support/autocad-map-3d/learn-explore/caas/CloudHelp/cloudhelp/2017/ENU/MAP3D-Use/files/GUID-C6B3BE91-1BC3-4679-87AE-64DD4A36FBD4-htm.html)).

Note that I'm only assuming that NTV2_0.GSB supersedes ntv1_can.dat, as the later file does not seem to be available from NRCan. According to [the Comments section of this NRCan resource](https://open.canada.ca/en/suggested-datasets/ntv2-grid-shift-files-gsb), NTV2_0.GSB is considered the most up-to-date.