### PR TITLE
Also exclude build_egm96_15_gtx from proj-datumgrid archives.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endforeach(GRIDFILE)
 set(CPACK_SOURCE_GENERATOR "TGZ;ZIP")
 set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY 0)
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "proj-datumgrid-${PROJ_DATUMGRID_VERSION_MAJOR}.${PROJ_DATUMGRID_VERSION_MINOR}")
-set(CPACK_SOURCE_IGNORE_FILES "/europe/;/oceania/;/north-america/;/build/;/cmake/;CMakeLists.txt;/lla/;HOWTORELEASE;/.github/;/.git/;.swp$;.*~;.*.py;.*.sh;${CPACK_SOURCE_IGNORE_FILES}")
+set(CPACK_SOURCE_IGNORE_FILES "/europe/;/oceania/;/north-america/;/build.*/;/cmake/;CMakeLists.txt;/lla/;HOWTORELEASE;/.github/;/.git/;.swp$;.*~;.*.py;.*.sh;${CPACK_SOURCE_IGNORE_FILES}")
 
 include(CPack)
 


### PR DESCRIPTION
See review of: #29