### PR TITLE
Add a proj-datumgrid-world package with EGM2008 geoid model (refs #2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ endforeach(GRIDFILE)
 set(CPACK_SOURCE_GENERATOR "TGZ;ZIP")
 set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY 0)
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "proj-datumgrid-${PROJ_DATUMGRID_VERSION_MAJOR}.${PROJ_DATUMGRID_VERSION_MINOR}")
-set(CPACK_SOURCE_IGNORE_FILES "/europe/;/oceania/;/north-america/;/build.*/;/cmake/;CMakeLists.txt;/lla/;HOWTORELEASE;/.github/;/.git/;.swp$;.*~;.*.py;.*.sh;${CPACK_SOURCE_IGNORE_FILES}")
+set(CPACK_SOURCE_IGNORE_FILES "/europe/;/oceania/;/north-america/;/world/;/build.*/;/cmake/;CMakeLists.txt;/lla/;HOWTORELEASE;/.github/;/.git/;.swp$;.*~;.*.py;.*.sh;${CPACK_SOURCE_IGNORE_FILES}")
 
 include(CPack)
 

--- a/README.DATUMGRID
+++ b/README.DATUMGRID
@@ -13,7 +13,12 @@ produced in PROJ 4.7.0 and older).
 ## About the Datum Grid package
 
 The datum grid package for PROJ is maintained on the OSGeo proj-datumgrid
-repository on [GitHub](https://github.com/OSGeo/proj-datumgrid).
+repository on [GitHub](https://github.com/OSGeo/proj-datumgrid). Anyone cloning
+it, or one of its forks, needs to install the Git Large File Storage (LFS)
+extension, due to the presence of files larger than 100 MB.
+Consult the [GitHub introduction to LFS](https://git-lfs.github.com/) for
+more information.
+
 All grids in the package are released under
 permissive licenses. New grids are accepted into the package as long as
 they are released under a license that is compatible with the [Open Source

--- a/README.DATUMGRID
+++ b/README.DATUMGRID
@@ -114,10 +114,6 @@ NAD83 to NAD83.
 
 15 minute worldwide geoid undulation grid that transforms WGS84 ellipsoidal heights to physical heights.
 
-This file has been produced by [GeographicLib](https://geographiclib.sourceforge.io/html/gravity.html)
-using the EGM96 gravity model and can be regenerated with the
-[build_egm96_15_gtx.sh](https://raw.githubusercontent.com/OSGeo/proj-datumgrid/master/build_egm96_15_gtx.sh) script.
-
 * egm96_15.gtx
 
 # Regional PROJ resource packages
@@ -129,6 +125,13 @@ PROJ-users in the package-specific regions.
 
 The regional packages can be downloaded from the
 [OSGeo download server](http://download.osgeo.org/proj/).
+
+### World
+
+This additional package with world scope contains files of big size.
+
+More information about the included grids and init files can be found in
+[README.WORLD](https://raw.githubusercontent.com/OSGeo/proj-datumgrid/master/world/README.WORLD)
 
 ### Europe
 

--- a/world/.gitattributes
+++ b/world/.gitattributes
@@ -1,0 +1,1 @@
+egm08_25.gtx filter=lfs diff=lfs merge=lfs -text

--- a/world/.github/README.md
+++ b/world/.github/README.md
@@ -1,0 +1,1 @@
+../README.WORLD

--- a/world/CMakeLists.txt
+++ b/world/CMakeLists.txt
@@ -1,0 +1,16 @@
+# CMake build system for proj-datumgrid-world releases.
+
+cmake_minimum_required(VERSION 2.6)
+
+project(PROJ_DATUMGRID_WORLD)
+set(PROJ_DATUMGRID_WORLD_VERSION_MAJOR 1)
+set(PROJ_DATUMGRID_WORLD_VERSION_MINOR 0alpha1)
+
+set(CPACK_SOURCE_GENERATOR "TGZ;ZIP")
+set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY 0)
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "proj-datumgrid-world-${PROJ_DATUMGRID_WORLD_VERSION_MAJOR}.${PROJ_DATUMGRID_WORLD_VERSION_MINOR}")
+set(CPACK_SOURCE_IGNORE_FILES "/build.*/;/cmake/;/.github/;CMakeLists.txt;.gitattributes;.swp$;.*~;.*.py;.*.sh;${CPACK_SOURCE_IGNORE_FILES}")
+
+include(CPack)
+
+add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)

--- a/world/README.WORLD
+++ b/world/README.WORLD
@@ -1,0 +1,27 @@
+# PROJ-DATUMGRID-WORLD
+
+The files in this package can be unpacked in the PROJ data directory.
+For an installed PROJ this may be /usr/local/share/proj or /usr/share/proj
+on unix style operating systems.
+
+## About the World PROJ resource package
+
+The World PROJ resource package is a collections of grids that are too large
+to be in the general purpose proj-datumgrid package and not essential for
+the functionality of PROJ, but still of general interest to PROJ-users.
+
+## Included grids
+
+### Vertical grid: EGM2008 geoid model
+
+*Source*: [NGA](http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm2008/egm08_wgs84.html)  
+*Format*: GTX
+*License*: Public Domain
+
+2.5 minute worldwide geoid undulation grid that transforms WGS84 ellipsoidal heights to physical heights.
+
+This file has been produced by [GeographicLib](https://geographiclib.sourceforge.io/html/gravity.html)
+using the EGM2008 gravity model and can be regenerated with the
+[build_egm08_25_gtx.sh](https://raw.githubusercontent.com/OSGeo/proj-datumgrid/master/world/build_egm08_25_gtx.sh) script.
+
+* egm08_25.gtx

--- a/world/build_egm08_25_gtx.sh
+++ b/world/build_egm08_25_gtx.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eu
+
+rm -rf build_egm08_25_gtx
+mkdir build_egm08_25_gtx
+cd build_egm08_25_gtx
+
+wget https://freefr.dl.sourceforge.net/project/geographiclib/distrib/GeographicLib-1.49.tar.gz
+tar xzf GeographicLib-1.49.tar.gz
+cd GeographicLib-1.49
+mkdir build
+cd build
+cmake .. -DGEOGRAPHICLIB_DATA=$PWD
+wget https://sourceforge.net/projects/geographiclib/files/gravity-distrib/egm2008.zip
+unzip egm2008.zip
+make GeoidToGTX -j9
+./examples/GeoidToGTX egm2008 24 egm08_25.gtx
+
+echo "egm08_25.gtx available in : $PWD/egm08_25.gtx"

--- a/world/egm08_25.gtx
+++ b/world/egm08_25.gtx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c18f20d1fe88616e3497a3eff993227371e1d9acc76f96253e8d84b475bbe6bf
+size 149333800


### PR DESCRIPTION
Note 1: As egm08_25.gtx is larger than 100 MB, github refuses to
store it as a normal file. Consequently clients have to install the
git-lfs git extension to handle such a large file.
See https://git-lfs.github.com/

Note 2: I made the exercice of using my build_egm08_25_gtx.sh script
and comparing its output with the file hosted at
https://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx

They differ by just one byte, likely a difference of rounding
between my computer/optimization switch/geographicLib version
and the environment used to generate it by Charles Karney.

$ diff -u egm08_25.gtx.txt /home/even/proj/proj-datumgrid/north-america/build_egm08_25_gtx/GeographicLib-1.49/build/egm08_25.gtx.txt
--- egm08_25.gtx.txt        2018-10-05 13:15:05.328739171 +0200
+++ /home/even/proj/proj-datumgrid/north-america/build_egm08_25_gtx/GeographicLib-1.49/build/egm08_25.gtx.txt       2018-10-05 13:15:26.627723531 +0200
@@ -3456157,7 +3456157,7 @@
    323050460 593f 243d 4b3f 4d53 3e3f dff2 323f f004
    323050500 223f 0308 0f3f a30f f63e baaf d13e 511b
    323050520 ad3e 1a2e 893e 23aa 4d3e ee7f 093e f6f7
-323050540 8d3d ec3e 55b6 4beb 92bd 4d03 0dbe 2f81
+323050540 8d3d ec3e 55b6 4aeb 92bd 4d03 0dbe 2f81
    323050560 46be 2c00 71be fbb1 8cbe 75b0 a5be cebe
    323050600 c9be 659c f8be f10a 15bf c93e 2cbf 2a48
    323050620 3ebf 1cea 4dbf 22c0 5abf 4890 66bf fb8d

I've included here the file from
https://download.osgeo.org/proj/vdatum/egm08_25/egm08_25.gtx to
remove any confusion.