### PR TITLE
Add a cmake check on the file of egm08_25.gtx to detect if git-lfs has been properly setup

### DIFF
--- a/world/CMakeLists.txt
+++ b/world/CMakeLists.txt
@@ -13,4 +13,17 @@ set(CPACK_SOURCE_IGNORE_FILES "/build.*/;/cmake/;/.github/;CMakeLists.txt;.gitat
 
 include(CPack)
 
+function(get_file_size var filename)
+    file(READ "${filename}" content HEX)
+    string(LENGTH "${content}" content_length)
+    math(EXPR content_length "${content_length} / 2")
+    set(${var} ${content_length} PARENT_SCOPE)
+endfunction()
+
+get_file_size(SIZE "egm08_25.gtx")
+set(EXPECTED_SIZE "149333800")
+if (NOT ${SIZE} STREQUAL ${EXPECTED_SIZE})
+    MESSAGE(FATAL_ERROR "Size of egm08_25.gtx is ${SIZE} instead of expected ${EXPECTED_SIZE}. git-lfs is likely not installed !")
+endif()
+
 add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)


### PR DESCRIPTION
Otherwise, egm08_25.gtx is a simple text file, and people might create
corrupted packages without realizing