### PR TITLE
Fix link to CONTRIBUTING.md

### DIFF
--- a/README.DATUMGRID
+++ b/README.DATUMGRID
@@ -32,7 +32,7 @@ is clearly stated and verifiable. Suitable licenses include:
   * CC-BY (v3.0 or later)
   * CC-BY-SA (v3.0 or later)
 
-Consult [CONTRIBUTING.md](CONTRIBUTING.md) to submit a new grid.
+Consult [CONTRIBUTING.md](https://github.com/OSGeo/proj-datumgrid/blob/master/CONTRIBUTING.md) to submit a new grid.
 
 ## Horizontal grids
 


### PR DESCRIPTION
Now the link points to nonexistent https://github.com/OSGeo/proj-datumgrid/blob/master/.github/CONTRIBUTING.md

The patch changes the link URL to https://github.com/OSGeo/proj-datumgrid/blob/master/CONTRIBUTING.md