### PR TITLE
proj-datumgrid-europe: add BWTA2017.gsb for DHDN->ETRS89 for Baden-Württemberg (fixes #22)

### DIFF
--- a/README.DATUMGRID
+++ b/README.DATUMGRID
@@ -69,6 +69,8 @@ Grid transformation from DE_DHDN to ETRS89 in Germany.
 
 * BETA2007.gsb
 
+Note: proj-datumgrid-europe includes the BWTA2017.gsb grid for Baden-Württemberg
+
 ### New Zealand: NZGD49 -> NZGD2000
 
 *Source*: [LINZ](https://www.linz.govt.nz/data/geodetic-system/download-geodetic-software/gd2000it-download)  

--- a/europe/BWTA2017.gsb
+++ b/europe/BWTA2017.gsb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbd54c5bc62c1a9f71b0d897a48d358a77faf902df840454f289c08b13a9eeb5
+size 392231712

--- a/europe/README.EUROPE
+++ b/europe/README.EUROPE
@@ -60,6 +60,16 @@ examples of use.
 * nkgrf03vel_realigned_xy.ct2
 * nkgrf03vel_realigned_z.gtx
 
+### Germany (Baden-Württemberg): DE_DHDN -> ETRS89
+
+*Source*: [LGL](https://www.lgl-bw.de/lgl-internet/opencms/de/05_Geoinformation/Liegenschaftskataster/ETRS89-UTM/)  
+*Format*: NTv2  
+*License*: [Data licence Germany – attribution – version 2.0](https://www.govdata.de/dl-de/by-2-0)
+
+Grid transformation from DE_DHDN to ETRS89 for Baden-Württemberg.
+
+* BWTA2017.gsb
+
 ### Ireland: OSGM15 height, Malin head datum -> ETRS89 ellipsoidal heights
 
 *Source*: [Ordnance Survey](https://www.ordnancesurvey.co.uk/business-and-government/help-and-support/navigation-technology/os-net/formats-for-developers.html)  

--- a/travis/expected_europe.lst
+++ b/travis/expected_europe.lst
@@ -1,4 +1,5 @@
 bd72lb72_etrs89lb08.gsb
+BWTA2017.gsb
 CGVD2013RGSPM06.gtx
 CHENyx06a.gsb
 CHENyx06_ETRS.gsb


### PR DESCRIPTION
This grid is licensed under the https://www.govdata.de/dl-de/by-2-0
"Data licence Germany – attribution – version 2.0" license listed by
https://opendefinition.org/licenses/ as a "Other conformant licenses", in the
same category as the license for the Canadian NTv2 grids we already have.

The file has been added to git-lfs given its size close to 400 MB.